### PR TITLE
Add scoring method comparison tests for attribute search

### DIFF
--- a/demos/search/validate_attribute.py
+++ b/demos/search/validate_attribute.py
@@ -7,27 +7,23 @@ of attribute-based searching to verify the strategy works correctly.
 
 import os
 import sys
-from typing import Dict, Any, List
+from typing import Any, Dict, List
 
 # Add the project root to the path
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../..")))
 
-from memory.search.strategies.attribute import AttributeSearchStrategy
-from memory.storage.redis_im import RedisIMStore
-from memory.storage.redis_stm import RedisSTMStore
-from memory.storage.sqlite_ltm import SQLiteLTMStore
-from memory.core import AgentMemorySystem
-
 from demos.demo_utils import (
-    setup_logging,
-    log_print,
     create_memory_system,
+    log_print,
     pretty_print_memories,
+    setup_logging,
 )
+from memory.search.strategies.attribute import AttributeSearchStrategy
 
 # Constants
 AGENT_ID = "test-agent-attribute-search"
 MEMORY_SAMPLE = "attribute_validation_memory.json"
+
 
 def run_test(
     search_strategy: AttributeSearchStrategy,
@@ -42,29 +38,36 @@ def run_test(
     match_all: bool = False,
     case_sensitive: bool = False,
     use_regex: bool = False,
+    scoring_method: str = None,
 ) -> List[Dict[str, Any]]:
     """Run a test case and return the results."""
     log_print(logger, f"\n=== Test: {test_name} ===")
-    
+
     if isinstance(query, dict):
         log_print(logger, f"Query (dict): {query}")
     else:
         log_print(logger, f"Query: '{query}'")
-    
-    log_print(logger, f"Match All: {match_all}, Case Sensitive: {case_sensitive}, Use Regex: {use_regex}")
-    
+
+    log_print(
+        logger,
+        f"Match All: {match_all}, Case Sensitive: {case_sensitive}, Use Regex: {use_regex}",
+    )
+
     if metadata_filter:
         log_print(logger, f"Metadata Filter: {metadata_filter}")
-    
+
     if tier:
         log_print(logger, f"Tier: {tier}")
-    
+
     if content_fields:
         log_print(logger, f"Content Fields: {content_fields}")
-    
+
     if metadata_fields:
         log_print(logger, f"Metadata Fields: {metadata_fields}")
-    
+
+    if scoring_method:
+        log_print(logger, f"Scoring Method: {scoring_method}")
+
     results = search_strategy.search(
         query=query,
         agent_id=agent_id,
@@ -76,12 +79,22 @@ def run_test(
         match_all=match_all,
         case_sensitive=case_sensitive,
         use_regex=use_regex,
+        scoring_method=scoring_method,
     )
-    
+
     log_print(logger, f"Found {len(results)} results")
     pretty_print_memories(results, f"Results for {test_name}", logger)
-    
+
+    # If we have scoring method, print the scores for comparison
+    if scoring_method and results:
+        log_print(logger, f"\nScores using {scoring_method} scoring method:")
+        for idx, result in enumerate(results[:5]):  # Show scores for top 5 results
+            score = result.get("metadata", {}).get("attribute_score", 0)
+            memory_id = result.get("memory_id", result.get("id", f"Result {idx+1}"))
+            log_print(logger, f"  {memory_id}: {score:.4f}")
+
     return results
+
 
 def validate_attribute_search():
     """Run validation tests for the attribute search strategy."""
@@ -91,24 +104,22 @@ def validate_attribute_search():
         memory_file=MEMORY_SAMPLE,
         use_mock_redis=True,
     )
-    
+
     # If memory system failed to load, exit
     if not memory_system:
         log_print(logger, "Failed to load memory system")
         return
-    
+
     # Setup search strategy
     agent = memory_system.get_memory_agent(AGENT_ID)
     search_strategy = AttributeSearchStrategy(
-        agent.stm_store, 
-        agent.im_store, 
-        agent.ltm_store
+        agent.stm_store, agent.im_store, agent.ltm_store
     )
-    
+
     # Print strategy info
     log_print(logger, f"Testing search strategy: {search_strategy.name()}")
     log_print(logger, f"Description: {search_strategy.description()}")
-    
+
     # Test 1: Basic content search
     run_test(
         search_strategy,
@@ -116,7 +127,7 @@ def validate_attribute_search():
         "meeting",
         AGENT_ID,
     )
-    
+
     # Test 2: Case sensitive search
     run_test(
         search_strategy,
@@ -125,7 +136,7 @@ def validate_attribute_search():
         AGENT_ID,
         case_sensitive=True,
     )
-    
+
     # Test 3: Search by metadata type
     run_test(
         search_strategy,
@@ -133,7 +144,7 @@ def validate_attribute_search():
         {"metadata": {"type": "meeting"}},
         AGENT_ID,
     )
-    
+
     # Test 4: Search with match_all
     run_test(
         search_strategy,
@@ -142,7 +153,7 @@ def validate_attribute_search():
         AGENT_ID,
         match_all=True,
     )
-    
+
     # Test 5: Search specific memory tier
     run_test(
         search_strategy,
@@ -151,7 +162,7 @@ def validate_attribute_search():
         AGENT_ID,
         tier="stm",
     )
-    
+
     # Test 6: Search with regex
     run_test(
         search_strategy,
@@ -160,7 +171,7 @@ def validate_attribute_search():
         AGENT_ID,
         use_regex=True,
     )
-    
+
     # Test 7: Search with metadata filter
     run_test(
         search_strategy,
@@ -169,7 +180,7 @@ def validate_attribute_search():
         AGENT_ID,
         metadata_filter={"content.metadata.importance": "high"},
     )
-    
+
     # Test 8: Search in specific content fields
     run_test(
         search_strategy,
@@ -178,7 +189,7 @@ def validate_attribute_search():
         AGENT_ID,
         content_fields=["content.content"],
     )
-    
+
     # Test 9: Search in specific metadata fields
     run_test(
         search_strategy,
@@ -187,7 +198,7 @@ def validate_attribute_search():
         AGENT_ID,
         metadata_fields=["content.metadata.tags"],
     )
-    
+
     # Test 10: Search with complex query and filters
     run_test(
         search_strategy,
@@ -198,11 +209,285 @@ def validate_attribute_search():
         match_all=True,
     )
 
+    # Test 11: Empty query handling - string
+    run_test(
+        search_strategy,
+        "Empty String Query",
+        "",
+        AGENT_ID,
+    )
+
+    # Test 12: Empty query handling - dict
+    run_test(
+        search_strategy,
+        "Empty Dict Query",
+        {},
+        AGENT_ID,
+    )
+
+    # Test 13: Numeric value search
+    run_test(
+        search_strategy,
+        "Numeric Value Search",
+        42,
+        AGENT_ID,
+    )
+
+    # Test 14: Boolean value search
+    run_test(
+        search_strategy,
+        "Boolean Value Search",
+        {"metadata": {"completed": True}},
+        AGENT_ID,
+    )
+
+    # Test 15: Type conversion - searching string with numeric
+    run_test(
+        search_strategy,
+        "Type Conversion - String Field with Numeric",
+        123,
+        AGENT_ID,
+        content_fields=["content.content"],
+    )
+
+    # Test 16: Invalid regex pattern handling
+    run_test(
+        search_strategy,
+        "Invalid Regex Pattern",
+        "[unclosed-bracket",
+        AGENT_ID,
+        use_regex=True,
+    )
+
+    # Test 17: Array field partial matching
+    run_test(
+        search_strategy,
+        "Array Field Partial Matching",
+        "dev",
+        AGENT_ID,
+        metadata_fields=["content.metadata.tags"],
+    )
+
+    # Test 18: Special characters in search
+    run_test(
+        search_strategy,
+        "Special Characters in Search",
+        "meeting+notes",
+        AGENT_ID,
+    )
+
+    # Test 19: Multi-tier search
+    run_test(
+        search_strategy,
+        "Multi-Tier Search",
+        "important",
+        AGENT_ID,
+        # No tier specified means searching all tiers
+    )
+
+    # Test 20: Large result set limiting
+    run_test(
+        search_strategy,
+        "Large Result Set Limiting",
+        "a",  # Common letter to match many memories
+        AGENT_ID,
+        limit=3,  # Only show top 3 results
+    )
+
+    # ===== New tests for scoring methods =====
+    log_print(logger, "\n=== SCORING METHOD COMPARISON TESTS ===")
+
+    # Test 21: Comparing scoring methods on the same query
+    test_query = "meeting"
+    log_print(logger, f"\nComparing scoring methods for query: '{test_query}'")
+
+    # Try each scoring method and collect results
+    length_ratio_results = run_test(
+        search_strategy,
+        "Default Length Ratio Scoring",
+        test_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="length_ratio",
+    )
+
+    term_freq_results = run_test(
+        search_strategy,
+        "Term Frequency Scoring",
+        test_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="term_frequency",
+    )
+
+    bm25_results = run_test(
+        search_strategy,
+        "BM25 Scoring",
+        test_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="bm25",
+    )
+
+    binary_results = run_test(
+        search_strategy,
+        "Binary Scoring",
+        test_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="binary",
+    )
+
+    # Test 22: Testing scoring on a document with repeated terms
+    test_with_repetition_query = "security"  # Look for security-related memories
+    log_print(
+        logger,
+        f"\nComparing scoring methods for query with potential term repetition: '{test_with_repetition_query}'",
+    )
+
+    # Test with default length ratio scoring
+    run_test(
+        search_strategy,
+        "Default Scoring with Term Repetition",
+        test_with_repetition_query,
+        AGENT_ID,
+        limit=5,
+    )
+
+    # Test with term frequency scoring - should favor documents with more occurrences
+    run_test(
+        search_strategy,
+        "Term Frequency with Term Repetition",
+        test_with_repetition_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="term_frequency",
+    )
+
+    # Test with BM25 scoring - balances term frequency and document length
+    run_test(
+        search_strategy,
+        "BM25 with Term Repetition",
+        test_with_repetition_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="bm25",
+    )
+
+    # Test 23: Testing with a specialized search strategy for each method
+    log_print(
+        logger,
+        "\nTesting with dedicated search strategy instances for each scoring method",
+    )
+
+    # Create specialized strategy instances
+    term_freq_strategy = AttributeSearchStrategy(
+        agent.stm_store,
+        agent.im_store,
+        agent.ltm_store,
+        scoring_method="term_frequency",
+    )
+
+    bm25_strategy = AttributeSearchStrategy(
+        agent.stm_store,
+        agent.im_store,
+        agent.ltm_store,
+        scoring_method="bm25",
+    )
+
+    # Run test with specialized strategies
+    run_test(
+        term_freq_strategy,
+        "Using Term Frequency Strategy Instance",
+        "project",
+        AGENT_ID,
+        limit=5,
+    )
+
+    run_test(
+        bm25_strategy,
+        "Using BM25 Strategy Instance",
+        "project",
+        AGENT_ID,
+        limit=5,
+    )
+
+    # Test 24: Testing with a long document vs short document comparison
+    # Change from "detailed" (no matches) to "authentication system" (appears in memories of different lengths)
+    long_doc_query = "authentication system"
+    log_print(
+        logger,
+        f"\nComparing scoring methods for long vs short document query: '{long_doc_query}'",
+    )
+
+    # Compare each scoring method
+    run_test(
+        search_strategy,
+        "Length Ratio for Long Documents",
+        long_doc_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="length_ratio",
+    )
+
+    run_test(
+        search_strategy,
+        "Term Frequency for Long Documents",
+        long_doc_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="term_frequency",
+    )
+
+    run_test(
+        search_strategy,
+        "BM25 for Long Documents",
+        long_doc_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="bm25",
+    )
+
+    # Test 25: Testing with a query that matches varying document length and context
+    varying_length_query = "documentation"
+    log_print(
+        logger,
+        f"\nComparing scoring methods for documents of varying lengths: '{varying_length_query}'",
+    )
+
+    run_test(
+        search_strategy,
+        "Length Ratio for Documentation Query",
+        varying_length_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="length_ratio",
+    )
+
+    run_test(
+        search_strategy,
+        "Term Frequency for Documentation Query",
+        varying_length_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="term_frequency",
+    )
+
+    run_test(
+        search_strategy,
+        "BM25 for Documentation Query",
+        varying_length_query,
+        AGENT_ID,
+        limit=5,
+        scoring_method="bm25",
+    )
+
+
 if __name__ == "__main__":
     # Setup logging
     logger = setup_logging("validate_attribute_search")
     log_print(logger, "Starting Attribute Search Strategy Validation")
-    
+
     validate_attribute_search()
-    
+
     log_print(logger, "Validation Complete")

--- a/memory/search/strategies/attribute.py
+++ b/memory/search/strategies/attribute.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import copy
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from memory.search.strategies.base import SearchStrategy
@@ -409,7 +410,7 @@ class AttributeSearchStrategy(SearchStrategy):
         for memory in memories:
             # Make a deep copy of the memory to avoid modifying the original
             # This ensures we don't lose any existing metadata when filtering
-            memory_copy = memory.copy()
+            memory_copy = copy.deepcopy(memory)
             if "metadata" not in memory_copy and "metadata" in memory:
                 memory_copy["metadata"] = memory["metadata"].copy()
 
@@ -683,8 +684,8 @@ class AttributeSearchStrategy(SearchStrategy):
 
         scored_memories = []
         for memory in memories:
-            # Create a copy of memory to avoid modifying the original
-            memory_copy = memory.copy()
+            # Create a deep copy of memory to avoid modifying the original
+            memory_copy = copy.deepcopy(memory)
 
             # Initialize score components
             match_count = 0


### PR DESCRIPTION
## Changes
- Added `scoring_method` parameter to `run_test()` function
- Implemented score display for search results when a scoring method is specified
- Added 15 new test cases (tests 11-25) to validate different search scenarios
- Added comprehensive scoring method comparison tests for:
  - Length ratio scoring (default)
  - Term frequency scoring
  - BM25 scoring
  - Binary scoring

## Purpose
These changes expand the validation suite for attribute-based searching to test different scoring methods. This allows developers to compare how different scoring algorithms rank search results across various query patterns and document types.

## Testing
All existing tests continue to pass. The new tests verify scoring behavior across different scenarios including:
- Documents with repeated terms
- Long vs short document comparisons
- Specialized search strategies
- Various query types (empty, numeric, boolean, arrays)
