### PR TITLE
Update memory retrieval methods and enhance .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,5 @@ results/
 .vscode/*
 
 node_modules/
+
+*.db

--- a/demos/01_basic_memory_operations.py
+++ b/demos/01_basic_memory_operations.py
@@ -149,7 +149,7 @@ def validate_memory_statistics(logger, stats, agent_id, memory_system):
     all_memories = []
     all_memories.extend(memory_agent.stm_store.get_all(agent_id))
     all_memories.extend(memory_agent.im_store.get_all(agent_id))
-    all_memories.extend(memory_agent.ltm_store.get_all())
+    all_memories.extend(memory_agent.ltm_store.get_all(agent_id))
 
     # Count by memory type
     memory_types = {"state": 0, "action": 0, "interaction": 0}
@@ -234,7 +234,7 @@ def validate_memory_statistics(logger, stats, agent_id, memory_system):
 
             # Also check LTM if still missing
             if step in missing_steps:
-                memories = memory_agent.ltm_store.get_all()
+                memories = memory_agent.ltm_store.get_all(agent_id)
                 for memory in memories:
                     step_number = memory.get("step_number")
                     if step_number == step:
@@ -432,7 +432,7 @@ def run_demo():
 
     # LTM example content
     log_print(logger, "\n----- LONG-TERM MEMORY (LTM) EXAMPLES -----")
-    ltm_memories = memory_agent.ltm_store.get_all()
+    ltm_memories = memory_agent.ltm_store.get_all(agent_id)
 
     if ltm_memories:
         for i, memory in enumerate(ltm_memories[:3]):  # Show up to 3 examples
@@ -499,7 +499,7 @@ def run_demo():
         for store_memories in [
             memory_agent.stm_store.get_all(agent_id),
             memory_agent.im_store.get_all(agent_id),
-            memory_agent.ltm_store.get_all(),
+            memory_agent.ltm_store.get_all(agent_id),
         ]:
             for memory in store_memories:
                 mem_step = memory.get("step_number")
@@ -569,7 +569,7 @@ def run_demo():
             # Directly check if we can find any memories with this timestamp across all three tiers
             stm_memories = memory_agent.stm_store.get_all(agent_id)
             im_memories = memory_agent.im_store.get_all(agent_id)
-            ltm_memories = memory_agent.ltm_store.get_all()
+            ltm_memories = memory_agent.ltm_store.get_all(agent_id)
             log_print(
                 logger, f"Searching for step {missing_step} manually in all stores..."
             )

--- a/demos/02_memory_retrieval.py
+++ b/demos/02_memory_retrieval.py
@@ -73,7 +73,7 @@ def validate_memory_statistics(logger, stats, agent_id, memory_system):
     all_memories = []
     all_memories.extend(memory_agent.stm_store.get_all(agent_id))
     all_memories.extend(memory_agent.im_store.get_all(agent_id))
-    all_memories.extend(memory_agent.ltm_store.get_all())
+    all_memories.extend(memory_agent.ltm_store.get_all(agent_id))
 
     # Count by memory type
     memory_types = {"state": 0, "action": 0, "interaction": 0}

--- a/memory/agent_memory.py
+++ b/memory/agent_memory.py
@@ -636,21 +636,24 @@ class MemoryAgent:
                     "avg_importance": self._calculate_tier_importance("ltm"),
                     "compression_ratio": self._calculate_compression_ratio("ltm"),
                 },
-            }
+            },
         }
 
         if not simplified:
-            stats.update({
-                "total_memories": (
-                    self.stm_store.count(self.agent_id)
-                    + self.im_store.count(self.agent_id)
-                    + self.ltm_store.count()
-                ),
-                "memory_types": self._get_memory_type_distribution(),
-                "access_patterns": self._get_access_patterns(),
-            })
+            stats.update(
+                {
+                    "total_memories": (
+                        self.stm_store.count(self.agent_id)
+                        + self.im_store.count(self.agent_id)
+                        + self.ltm_store.count()
+                    ),
+                    "memory_types": self._get_memory_type_distribution(),
+                    "access_patterns": self._get_access_patterns(),
+                }
+            )
 
         return stats
+
     def force_maintenance(self) -> bool:
         """Force memory tier transitions and cleanup operations.
 
@@ -832,10 +835,8 @@ class MemoryAgent:
     def _calculate_tier_importance(self, tier: str) -> float:
         """Calculate average importance score for a memory tier."""
         store = getattr(self, f"{tier}_store")
-        if tier in ["stm", "im"]:
-            memories = store.get_all(self.agent_id)
-        else:
-            memories = store.get_all()
+
+        memories = store.get_all(self.agent_id)
 
         if not memories:
             return 0.0
@@ -878,10 +879,8 @@ class MemoryAgent:
 
         for store_name in ["stm_store", "im_store", "ltm_store"]:
             store = getattr(self, store_name)
-            if store_name in ["stm_store", "im_store"]:
-                memories = store.get_all(self.agent_id)
-            else:
-                memories = store.get_all()
+
+            memories = store.get_all(self.agent_id)
 
             for memory in memories:
                 memory_type = memory["metadata"]["memory_type"]
@@ -901,10 +900,7 @@ class MemoryAgent:
         all_memories = []
         for store_name in ["stm_store", "im_store", "ltm_store"]:
             store = getattr(self, store_name)
-            if store_name in ["stm_store", "im_store"]:
-                all_memories.extend(store.get_all(self.agent_id))
-            else:
-                all_memories.extend(store.get_all())
+            all_memories.extend(store.get_all(self.agent_id))
 
         if not all_memories:
             return patterns

--- a/memory/search/strategies/attribute.py
+++ b/memory/search/strategies/attribute.py
@@ -213,7 +213,7 @@ class AttributeSearchStrategy(SearchStrategy):
             elif current_tier == "im":
                 tier_memories = self.im_store.get_all(agent_id)
             else:  # ltm
-                tier_memories = self.ltm_store.get_all()
+                tier_memories = self.ltm_store.get_all(agent_id)
 
             # Filter memories by query conditions and metadata
             filtered_memories = self._filter_memories(

--- a/memory/search/strategies/step.py
+++ b/memory/search/strategies/step.py
@@ -152,7 +152,7 @@ class StepBasedSearchStrategy(SearchStrategy):
             elif current_tier == "im":
                 tier_memories = self.im_store.get_all(agent_id)
             else:  # ltm
-                tier_memories = self.ltm_store.get_all()
+                tier_memories = self.ltm_store.get_all(agent_id)
 
             # Filter memories by step range and metadata
             filtered_memories = self._filter_memories(

--- a/tasm_visualizer.py
+++ b/tasm_visualizer.py
@@ -557,7 +557,7 @@ class TASMVisualizer:
 
         # Get LTM memories
         try:
-            ltm_memories = memory_agent.ltm_store.get_all(limit=1000)
+            ltm_memories = memory_agent.ltm_store.get_all(agent_id=agent_id)
             self.memory_contents["LTM"] = ltm_memories
             self.ltm_text.delete(1.0, tk.END)
             self.ltm_text.insert(tk.END, f"LTM Memories: {len(ltm_memories)}\n\n")

--- a/tests/storage/test_sqlite_ltm.py
+++ b/tests/storage/test_sqlite_ltm.py
@@ -320,13 +320,13 @@ class TestSQLiteLTMStore:
         ltm_store.store_batch(sample_memories)
         
         # Get all memories
-        all_memories = ltm_store.get_all()
+        all_memories = ltm_store.get_all(agent_id="test_agent")
         
         # Should match the number of memories we stored
         assert len(all_memories) == len(sample_memories)
         
         # Test with limit
-        limited_memories = ltm_store.get_all(limit=2)
+        limited_memories = ltm_store.get_all(agent_id="test_agent", limit=2)
         assert len(limited_memories) == 2
 
     def test_delete(self, ltm_store, sample_memory):

--- a/tests/storage/test_sqlite_ltm_integration.py
+++ b/tests/storage/test_sqlite_ltm_integration.py
@@ -363,8 +363,8 @@ class TestSQLiteLTMStoreIntegration:
             assert agent2_store.get(f"agent1_memory_{i}") is None
         
         # Retrieve all memories for each agent
-        agent1_memories = agent1_store.get_all()
-        agent2_memories = agent2_store.get_all()
+        agent1_memories = agent1_store.get_all(agent_id="agent1")
+        agent2_memories = agent2_store.get_all(agent_id="agent2")
         
         # Verify each agent only sees their own memories
         assert all(memory["agent_id"] == "agent1" for memory in agent1_memories)


### PR DESCRIPTION
This commit modifies the memory retrieval logic in the `SQLiteLTMStore` class to require an `agent_id` parameter in the `get_all` method, ensuring that memories are fetched specific to each agent. Additionally, it updates the test cases to reflect this change, verifying that agents only access their own memories. The `.gitignore` file is also updated to exclude database files, improving project cleanliness.