### PR TITLE
Refactor memory retrieval logic in MemoryAgent to simplify agent_id h…

### DIFF
--- a/memory/agent_memory.py
+++ b/memory/agent_memory.py
@@ -858,10 +858,7 @@ class MemoryAgent:
             return 0.0
 
         # Get original size from metadata
-        if tier in ["stm", "im"]:
-            memories = store.get_all(self.agent_id)
-        else:
-            memories = store.get_all()
+        memories = store.get_all(self.agent_id)
 
         if not memories:
             return 0.0


### PR DESCRIPTION
…andling

This commit streamlines the memory retrieval process in the `MemoryAgent` class by removing conditional checks for the `tier` parameter when fetching memories. The `get_all` method is now consistently called with the `agent_id`, ensuring that memory retrieval is specific to the agent, thereby improving code clarity and maintainability.