### PR TITLE
Add checksum functionality to memory entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## [0.1.1] - 2025-04-25
+
+### Added
+- Added checksum functionality to memory metadata:
+  - New `checksum` field in `MemoryMetadata` for data integrity verification
+  - Added utility functions in `memory/utils/checksums.py` for generating and validating checksums
+  - Implemented automatic checksum generation when storing memories
+  - Added checksum validation when retrieving memories
+  - Added integrity verification flags in memory metadata
+
+### Improved
+- Enhanced data integrity through checksum verification across all memory tiers
+- Added support for different hashing algorithms in checksum generation
+- Implemented comprehensive test suite for checksum functionality
+
 ## [0.1.0] - 2025-04-05
 
 ### Refactoring

--- a/add_checksums_to_samples.py
+++ b/add_checksums_to_samples.py
@@ -1,0 +1,96 @@
+"""
+Add checksums to sample memory files.
+
+This script processes all memory JSON files in the demos/memory_samples directory,
+adds checksums to each memory entry's metadata, and saves the updated files.
+"""
+
+import json
+import os
+from pathlib import Path
+import sys
+
+# Add project root to path so we can import the memory module
+sys.path.append(os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from memory.utils.checksums import add_checksum_to_memory
+
+def process_memory_file(file_path):
+    """Process a memory file and add checksums to all memory entries."""
+    print(f"Processing {file_path}...")
+    
+    # Read the memory file
+    with open(file_path, 'r', encoding='utf-8') as f:
+        memory_data = json.load(f)
+    
+    # Track if we made any changes
+    changes_made = False
+    
+    # Process single agent memory format
+    if "agents" in memory_data:
+        for agent_id, agent_data in memory_data["agents"].items():
+            if "memories" in agent_data:
+                for i, memory_entry in enumerate(agent_data["memories"]):
+                    # Add checksum if not already present
+                    if "metadata" not in memory_entry or "checksum" not in memory_entry["metadata"]:
+                        # Identify the content field (could be content or contents)
+                        if "content" in memory_entry:
+                            agent_data["memories"][i] = add_checksum_to_memory(memory_entry)
+                            changes_made = True
+                        elif "contents" in memory_entry:
+                            agent_data["memories"][i] = add_checksum_to_memory(memory_entry)
+                            changes_made = True
+    
+    # Process array of memories format (for other sample files)
+    elif isinstance(memory_data, list):
+        for i, memory_entry in enumerate(memory_data):
+            # Add checksum if not already present
+            if "metadata" not in memory_entry or "checksum" not in memory_entry["metadata"]:
+                # Identify the content field (could be content or contents)
+                if "content" in memory_entry:
+                    memory_data[i] = add_checksum_to_memory(memory_entry)
+                    changes_made = True
+                elif "contents" in memory_entry:
+                    memory_data[i] = add_checksum_to_memory(memory_entry)
+                    changes_made = True
+    
+    # Save the updated file with checksums
+    if changes_made:
+        # Create backup of original file
+        backup_path = str(file_path) + '.backup'
+        if not os.path.exists(backup_path):
+            os.rename(file_path, backup_path)
+            print(f"Created backup at {backup_path}")
+        
+        # Write updated file
+        with open(file_path, 'w', encoding='utf-8') as f:
+            json.dump(memory_data, f, indent=2)
+        print(f"Updated {file_path} with checksums")
+    else:
+        print(f"No changes made to {file_path}")
+
+def main():
+    # Get the directory containing the sample memory files
+    samples_dir = Path('demos/memory_samples')
+    
+    # Check if directory exists
+    if not samples_dir.exists():
+        print(f"Error: Directory {samples_dir} does not exist")
+        return
+    
+    # Process all JSON files in the directory
+    json_files = list(samples_dir.glob('*.json'))
+    
+    if not json_files:
+        print(f"No JSON files found in {samples_dir}")
+        return
+    
+    print(f"Found {len(json_files)} memory files to process")
+    
+    for file_path in json_files:
+        if '.backup' not in str(file_path):  # Skip backup files
+            process_memory_file(file_path)
+    
+    print("Processing complete")
+
+if __name__ == "__main__":
+    main() 

--- a/demos/memory_samples/attribute_validation_memory.json
+++ b/demos/memory_samples/attribute_validation_memory.json
@@ -57,7 +57,8 @@
             "importance_score": 0.9,
             "retrieval_count": 0,
             "memory_type": "interaction",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "0eb0f81d07276f08e05351a604d3c994564fedee3a93329e318186da517a3c56"
           },
           "type": "interaction",
           "embeddings": {}
@@ -88,7 +89,8 @@
             "importance_score": 0.7,
             "retrieval_count": 0,
             "memory_type": "action",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "e0f7deb6929a17f65f56e5b03e16067c8bb65649fd2745f842aca7af701c9cac"
           },
           "type": "action",
           "embeddings": {}
@@ -124,7 +126,8 @@
             "importance_score": 0.6,
             "retrieval_count": 0,
             "memory_type": "interaction",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "f6ab36930459e74a52fdf21fb96a84241ccae3f6987365a21f9a17d84c5dae1e"
           },
           "type": "interaction",
           "embeddings": {}
@@ -154,7 +157,8 @@
             "importance_score": 0.95,
             "retrieval_count": 0,
             "memory_type": "generic",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "1e9e265e75c2ef678dfd0de0ab5c801f845daa48a90a48bb02ee85148ccc3470"
           },
           "type": "generic",
           "embeddings": {}
@@ -184,7 +188,8 @@
             "importance_score": 0.4,
             "retrieval_count": 0,
             "memory_type": "generic",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "496d09718bbc8ae669dffdd782ed5b849fdbb1a57e3f7d07e61807b10e650092"
           },
           "type": "generic",
           "embeddings": {}
@@ -220,7 +225,8 @@
             "importance_score": 0.85,
             "retrieval_count": 3,
             "memory_type": "interaction",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "ffa0ee60ebaec5574358a02d1857823e948519244e366757235bf755c888a87f"
           },
           "type": "interaction",
           "embeddings": {}
@@ -251,7 +257,8 @@
             "importance_score": 0.8,
             "retrieval_count": 5,
             "memory_type": "action",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "1d23b6683acd8c3863cb2f2010fe3df2c3e69a2d94c7c4757a291d4872066cfd"
           },
           "type": "action",
           "embeddings": {}
@@ -281,7 +288,8 @@
             "importance_score": 0.7,
             "retrieval_count": 2,
             "memory_type": "generic",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "169c452e368fd62e3c0cf5ce7731769ed46ab6ae73e5048e0c3a7caaa66fba46"
           },
           "type": "generic",
           "embeddings": {}
@@ -319,7 +327,8 @@
             "importance_score": 0.9,
             "retrieval_count": 8,
             "memory_type": "interaction",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "9214ebc2d11877665b32771bd3c080414d9519b435ec3f6c19cc5f337bb0ba90"
           },
           "type": "interaction",
           "embeddings": {}
@@ -351,7 +360,8 @@
             "importance_score": 0.85,
             "retrieval_count": 10,
             "memory_type": "action",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "f3c73b06d6399ed30ea9d9ad7c711a86dd58154809cc05497f8955425ec6dc67"
           },
           "type": "action",
           "embeddings": {}
@@ -388,7 +398,8 @@
             "importance_score": 0.9,
             "retrieval_count": 7,
             "memory_type": "interaction",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "ad2e7c963751beb1ebc1c9b84ecb09ec3ccdef14f276cd14bbebad12d0f9b0df"
           },
           "type": "interaction",
           "embeddings": {}

--- a/demos/memory_samples/importance_validation_memory.json
+++ b/demos/memory_samples/importance_validation_memory.json
@@ -51,7 +51,8 @@
             "importance_score": 0.95,
             "retrieval_count": 0,
             "memory_type": "generic",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "319f9c037be95ae4dc07458da21598ff7b47ae13d08f82a3c313797384b6767a"
           },
           "type": "generic",
           "embeddings": {}
@@ -85,7 +86,8 @@
             "importance_score": 0.85,
             "retrieval_count": 0,
             "memory_type": "interaction",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "90041b1b5cadc1bb90c28529d2544256dd97368aafceb974f35fb242a1c69269"
           },
           "type": "interaction",
           "embeddings": {}
@@ -117,7 +119,8 @@
             "importance_score": 0.65,
             "retrieval_count": 0,
             "memory_type": "interaction",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "876fee01bc2619d329ed55b0f2759d7ecf5339797c19e2e8075f773bc9cb9b4d"
           },
           "type": "interaction",
           "embeddings": {}
@@ -146,7 +149,8 @@
             "importance_score": 0.6,
             "retrieval_count": 0,
             "memory_type": "action",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "7bfe771b5a0a4695620f2804649c508824ad84db0e18e7fd8e6bb681acc8260a"
           },
           "type": "action",
           "embeddings": {}
@@ -174,7 +178,8 @@
             "importance_score": 0.25,
             "retrieval_count": 0,
             "memory_type": "generic",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "ddfab123f24dfcf29703b4dafd985af5f9c044bfc28fcacd6624c3ce7001816b"
           },
           "type": "generic",
           "embeddings": {}
@@ -203,7 +208,8 @@
             "importance_score": 0.8,
             "retrieval_count": 3,
             "memory_type": "action",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "fcb1064d39b1a1b91b39fd34ec38a02e01634e7d02c277c46d1c0d09505d65be"
           },
           "type": "action",
           "embeddings": {}
@@ -233,7 +239,8 @@
             "importance_score": 0.87,
             "retrieval_count": 4,
             "memory_type": "generic",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "ad4f5ef4c9034624c4554aba72a259fe84712fdde43dd98fc9592f4265db278e"
           },
           "type": "generic",
           "embeddings": {}
@@ -262,7 +269,8 @@
             "importance_score": 0.55,
             "retrieval_count": 2,
             "memory_type": "generic",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "680b8f4fc00e1fec4f9e52db616a3dfdc84a01a3d927cb7ed96d7fb48f7edc3d"
           },
           "type": "generic",
           "embeddings": {}
@@ -291,7 +299,8 @@
             "importance_score": 0.68,
             "retrieval_count": 3,
             "memory_type": "generic",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "b37e10d66772a51ca03bd5af276e964e24ac11aef34ea2c066fe37b26e4b4e06"
           },
           "type": "generic",
           "embeddings": {}
@@ -320,7 +329,8 @@
             "importance_score": 0.3,
             "retrieval_count": 1,
             "memory_type": "interaction",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "2e658bac19ee9082ae6c71ca2847de58f1a1f294f7e2fbcba2fa3c7fddc54cc4"
           },
           "type": "interaction",
           "embeddings": {}
@@ -349,7 +359,8 @@
             "importance_score": 0.35,
             "retrieval_count": 2,
             "memory_type": "generic",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "8ae88e62d6cacb9be0a2fbef6efcaf7801017510fb4e20d05d07b14de8fdd267"
           },
           "type": "generic",
           "embeddings": {}
@@ -379,7 +390,8 @@
             "importance_score": 0.98,
             "retrieval_count": 15,
             "memory_type": "generic",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "f8dc98ec97fdf32711eed46322ae325f15fbd53fa5998c5f4640bf49e469d81c"
           },
           "type": "generic",
           "embeddings": {}
@@ -409,7 +421,8 @@
             "importance_score": 0.9,
             "retrieval_count": 10,
             "memory_type": "generic",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "68f7348745ae732fe013b7ed45d6c6f8f3f8caaf669ea43b04a349a17b432216"
           },
           "type": "generic",
           "embeddings": {}
@@ -438,7 +451,8 @@
             "importance_score": 0.7,
             "retrieval_count": 5,
             "memory_type": "generic",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "abd9577d127a2d63eb3c055b584503a73d90746aa6d8b2d941f83198a8c1506a"
           },
           "type": "generic",
           "embeddings": {}
@@ -467,7 +481,8 @@
             "importance_score": 0.4,
             "retrieval_count": 2,
             "memory_type": "generic",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "c2c86d3f7ef76ec4b9e54e48cb2160394b35693cc0a17f1cd93d4674942fb4da"
           },
           "type": "generic",
           "embeddings": {}

--- a/demos/memory_samples/multi_agent_memory.json
+++ b/demos/memory_samples/multi_agent_memory.json
@@ -15,7 +15,11 @@
           "timestamp": 1744852300,
           "content": {
             "role": "ai_assistant",
-            "capabilities": ["code_writing", "debugging", "explanation"]
+            "capabilities": [
+              "code_writing",
+              "debugging",
+              "explanation"
+            ]
           },
           "metadata": {
             "creation_time": 1744852300,
@@ -24,7 +28,8 @@
             "importance_score": 0.9,
             "retrieval_count": 0,
             "memory_type": "state",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "cd32c26539c4ff05bbb9890ce0f1223c8da8de753b69e2f1b882f4dd6221929c"
           },
           "type": "state",
           "embeddings": {}
@@ -47,7 +52,8 @@
             "importance_score": 0.8,
             "retrieval_count": 1,
             "memory_type": "interaction",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "2e96eaa0f1a4c3a53a81b79ea0b858f0df97564d18591d087046827e5aaf1753"
           },
           "type": "interaction",
           "embeddings": {}
@@ -65,7 +71,10 @@
           "content": {
             "role": "research_agent",
             "specialty": "algorithm_optimization",
-            "resources": ["academic_papers", "code_libraries"]
+            "resources": [
+              "academic_papers",
+              "code_libraries"
+            ]
           },
           "metadata": {
             "creation_time": 1744852320,
@@ -74,7 +83,8 @@
             "importance_score": 0.7,
             "retrieval_count": 0,
             "memory_type": "state",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "2adfc8369f327781bd06aff74feebe17e025598174df82f5a39b4d834a7105aa"
           },
           "type": "state",
           "embeddings": {}
@@ -87,7 +97,10 @@
           "content": {
             "action_type": "research",
             "query": "sorting_algorithm_optimization",
-            "results": ["quicksort_variants", "parallel_sorting"]
+            "results": [
+              "quicksort_variants",
+              "parallel_sorting"
+            ]
           },
           "metadata": {
             "creation_time": 1744852330,
@@ -96,7 +109,8 @@
             "importance_score": 0.9,
             "retrieval_count": 0,
             "memory_type": "action",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "b2a82bbe59cc0c5a4ff2b257edfebf6f7717f89030ef6070f7e299a4e67528c6"
           },
           "type": "action",
           "embeddings": {}
@@ -104,4 +118,4 @@
       ]
     }
   }
-} 
+}

--- a/demos/memory_samples/retrieval_demo_memory.json
+++ b/demos/memory_samples/retrieval_demo_memory.json
@@ -40,7 +40,11 @@
             },
             "health": 85,
             "energy": 90,
-            "inventory": ["sword", "potion", "map"],
+            "inventory": [
+              "sword",
+              "potion",
+              "map"
+            ],
             "level": 1
           },
           "metadata": {
@@ -50,7 +54,8 @@
             "importance_score": 0.8,
             "retrieval_count": 0,
             "memory_type": "state",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "32d58893c1e88ab72dc783e1d42c2fdf0b898ea47588306bdadb94138c6ca438"
           },
           "type": "state",
           "embeddings": {}
@@ -73,7 +78,8 @@
             "importance_score": 0.7,
             "retrieval_count": 0,
             "memory_type": "action",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "099ff0d5f5e5f993d40222837b96b719681757a3a92c4eccfbed97f0674f7e9b"
           },
           "type": "action",
           "embeddings": {}
@@ -91,7 +97,11 @@
             },
             "health": 75,
             "energy": 65,
-            "inventory": ["sword", "shield", "gem"],
+            "inventory": [
+              "sword",
+              "shield",
+              "gem"
+            ],
             "level": 2
           },
           "metadata": {
@@ -101,7 +111,8 @@
             "importance_score": 0.85,
             "retrieval_count": 2,
             "memory_type": "state",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "65203a5016774d347d68a98bdf90427882152da68b30cfa3666da6867a74c185"
           },
           "type": "state",
           "embeddings": {}
@@ -125,7 +136,8 @@
             "importance_score": 0.9,
             "retrieval_count": 1,
             "memory_type": "interaction",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "6bece8550b92538b488ad88e3844387f6fa2735c248bf27e7f58a2002f84943b"
           },
           "type": "interaction",
           "embeddings": {}
@@ -143,7 +155,12 @@
             },
             "health": 95,
             "energy": 85,
-            "inventory": ["sword", "potion", "gem", "key"],
+            "inventory": [
+              "sword",
+              "potion",
+              "gem",
+              "key"
+            ],
             "level": 2
           },
           "metadata": {
@@ -153,7 +170,8 @@
             "importance_score": 0.75,
             "retrieval_count": 3,
             "memory_type": "state",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "1207a8b50d634499520ab256d868633fcbed7952856c1ab18467b073ae252463"
           },
           "type": "state",
           "embeddings": {}
@@ -176,7 +194,8 @@
             "importance_score": 0.65,
             "retrieval_count": 0,
             "memory_type": "action",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "321b35c213c7467b90c72c8992f540b1db22897a5a88ec3262017e582767353f"
           },
           "type": "action",
           "embeddings": {}
@@ -200,7 +219,8 @@
             "importance_score": 0.8,
             "retrieval_count": 1,
             "memory_type": "interaction",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "79f19a12744bfcb17838b52986da6dd8d01018cacc00ce52d86a02b985e2c62b"
           },
           "type": "interaction",
           "embeddings": {}
@@ -218,7 +238,12 @@
             },
             "health": 65,
             "energy": 55,
-            "inventory": ["sword", "shield", "potion", "key"],
+            "inventory": [
+              "sword",
+              "shield",
+              "potion",
+              "key"
+            ],
             "level": 3
           },
           "metadata": {
@@ -228,7 +253,8 @@
             "importance_score": 0.95,
             "retrieval_count": 2,
             "memory_type": "state",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "ac2af592aafe7ce3a4ecd9a1da63539ec1f6daa59f224cf2532cbafbafe2ee3a"
           },
           "type": "state",
           "embeddings": {}
@@ -251,7 +277,8 @@
             "importance_score": 0.9,
             "retrieval_count": 1,
             "memory_type": "action",
-            "current_tier": "im"
+            "current_tier": "im",
+            "checksum": "1bfb2930a6f666e90d0ab089d5a830046d73235bffadf58ca7675bc201d0920d"
           },
           "type": "action",
           "embeddings": {}
@@ -269,7 +296,13 @@
             },
             "health": 90,
             "energy": 80,
-            "inventory": ["sword", "shield", "potion", "gem", "key"],
+            "inventory": [
+              "sword",
+              "shield",
+              "potion",
+              "gem",
+              "key"
+            ],
             "level": 4
           },
           "metadata": {
@@ -279,7 +312,8 @@
             "importance_score": 0.99,
             "retrieval_count": 5,
             "memory_type": "state",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "09713303e74d6312689602113d9a9bd6060b689b1736825e5d9252e6621c0048"
           },
           "type": "state",
           "embeddings": {}
@@ -303,7 +337,8 @@
             "importance_score": 0.98,
             "retrieval_count": 3,
             "memory_type": "interaction",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "22c1d959cefdd2247e7e78087b4df31a3c222666ffce4c1735eec3095a7a3cac"
           },
           "type": "interaction",
           "embeddings": {}
@@ -326,7 +361,8 @@
             "importance_score": 0.95,
             "retrieval_count": 2,
             "memory_type": "action",
-            "current_tier": "ltm"
+            "current_tier": "ltm",
+            "checksum": "15f234a52a480576ba34e1f0fd4c98c5d32d167be93b1fc9bee5cab11e1af69c"
           },
           "type": "action",
           "embeddings": {}
@@ -344,7 +380,13 @@
             },
             "health": 100,
             "energy": 100,
-            "inventory": ["sword", "shield", "potion", "gem", "map"],
+            "inventory": [
+              "sword",
+              "shield",
+              "potion",
+              "gem",
+              "map"
+            ],
             "level": 5
           },
           "metadata": {
@@ -354,7 +396,8 @@
             "importance_score": 0.85,
             "retrieval_count": 1,
             "memory_type": "state",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "5e8f97891d286ffca32b3dd3a20cdbec55dbed65193d1761ad9083ef624eba25"
           },
           "type": "state",
           "embeddings": {}
@@ -378,7 +421,8 @@
             "importance_score": 0.9,
             "retrieval_count": 0,
             "memory_type": "interaction",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "21fa9a10fcba0ddb05d81ea3afaedc3a2af8b966e32113ae9f9f4bdc4d1c5a14"
           },
           "type": "interaction",
           "embeddings": {}
@@ -401,7 +445,8 @@
             "importance_score": 0.7,
             "retrieval_count": 0,
             "memory_type": "action",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "3efd9b816b127b1fe4a89eaded9ea74405550df04dfe916328cb1c55d7a165eb"
           },
           "type": "action",
           "embeddings": {}
@@ -409,4 +454,4 @@
       ]
     }
   }
-} 
+}

--- a/demos/memory_samples/simple_agent_memory.json
+++ b/demos/memory_samples/simple_agent_memory.json
@@ -16,7 +16,10 @@
           "content": {
             "location": "home_office",
             "task": "writing_code",
-            "tools": ["laptop", "coffee"]
+            "tools": [
+              "laptop",
+              "coffee"
+            ]
           },
           "metadata": {
             "creation_time": 1744852255,
@@ -25,7 +28,8 @@
             "importance_score": 0.7,
             "retrieval_count": 0,
             "memory_type": "state",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "f08906f917e9236de6ffcadce68c5f34cb04965f239f389a24d3c40afc854a4a"
           },
           "type": "state",
           "embeddings": {}
@@ -48,7 +52,8 @@
             "importance_score": 0.8,
             "retrieval_count": 0,
             "memory_type": "interaction",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "0fa8b49d104b746a5ab79a7a633eda1c8f0a8bd7a2e973153aa950790fae4428"
           },
           "type": "interaction",
           "embeddings": {}
@@ -70,7 +75,8 @@
             "importance_score": 0.9,
             "retrieval_count": 0,
             "memory_type": "action",
-            "current_tier": "stm"
+            "current_tier": "stm",
+            "checksum": "e059d29b9f8d9c63c2aca5c1af50484acca925e86c784ab00b472480e3b18ae3"
           },
           "type": "action",
           "embeddings": {}

--- a/memory/api/types.py
+++ b/memory/api/types.py
@@ -100,6 +100,7 @@ class MemoryMetadata(TypedDict, total=False):
         retrieval_count: Number of times this memory has been retrieved
         memory_type: Classification of the memory content (state/action/interaction)
         current_tier: Current memory tier where this entry is stored (stm/im/ltm)
+        checksum: Hash value to verify data integrity of the memory content
     """
 
     creation_time: float
@@ -109,6 +110,7 @@ class MemoryMetadata(TypedDict, total=False):
     retrieval_count: int
     memory_type: Literal["state", "action", "interaction"]
     current_tier: MemoryTier
+    checksum: str
 
 
 class MemoryEmbeddings(TypedDict, total=False):

--- a/memory/storage/redis_im.py
+++ b/memory/storage/redis_im.py
@@ -25,6 +25,7 @@ import redis
 from memory.config import RedisIMConfig
 from memory.storage.redis_client import ResilientRedisClient
 from memory.storage.redis_factory import RedisFactory
+from memory.utils.checksums import generate_checksum, validate_checksum
 from memory.utils.error_handling import (
     Priority,
     RedisTimeoutError,
@@ -335,8 +336,12 @@ class RedisIMStore:
             else:
                 hash_values["content"] = str(content)
 
-            # Store metadata as JSON
+            # Generate checksum for content if not already in metadata
             metadata = memory_entry.get("metadata", {})
+            if "checksum" not in metadata and isinstance(content, (dict, list)):
+                metadata["checksum"] = generate_checksum(content)
+
+            # Store metadata as JSON
             hash_values["metadata"] = json.dumps(metadata)
 
             # Store specific metadata fields directly for easier access
@@ -344,6 +349,8 @@ class RedisIMStore:
             hash_values["importance_score"] = str(metadata.get("importance_score", 0.0))
             hash_values["retrieval_count"] = str(metadata.get("retrieval_count", 0))
             hash_values["creation_time"] = str(metadata.get("creation_time", timestamp))
+            if "checksum" in metadata:
+                hash_values["checksum"] = metadata["checksum"]
 
             # Store embedding as JSON if it exists
             embedding = memory_entry.get("embedding")
@@ -493,6 +500,21 @@ class RedisIMStore:
 
             # Convert hash data back to memory entry dict
             memory_entry = self._hash_to_memory_entry(hash_data)
+
+            # Validate checksum if present
+            metadata = memory_entry.get("metadata", {})
+            if "checksum" in metadata:
+                is_valid = validate_checksum(memory_entry)
+                if not is_valid:
+                    logger.warning(
+                        "Checksum validation failed for memory %s", memory_id
+                    )
+                    # Add integrity flag to metadata
+                    metadata["integrity_verified"] = False
+                    memory_entry["metadata"] = metadata
+                else:
+                    metadata["integrity_verified"] = True
+                    memory_entry["metadata"] = metadata
 
             # Update access metadata
             self._update_access_metadata(agent_id, memory_id, memory_entry)
@@ -1895,98 +1917,110 @@ class RedisIMStore:
                     f"Redis step range search failed, falling back to Python implementation: {e}"
                 )
                 # Fall back to optimized Python implementation
-        
+
         # Even without vector search capabilities, we can use Redis sorted sets or SCAN with pattern matching
         try:
             # Create a timeline key if using a sorted set approach
             timeline_key = self._get_timeline_key(agent_id)
-            
+
             # Check if we have a sorted set timeline index
             if self.redis.exists(timeline_key):
                 # Use Redis ZRANGEBYSCORE to get memory IDs in the step range
                 memory_ids = self.redis.zrangebyscore(
-                    timeline_key, 
-                    min=start_step, 
-                    max=end_step
+                    timeline_key, min=start_step, max=end_step
                 )
-                
+
                 results = []
                 for memory_id in memory_ids:
                     if isinstance(memory_id, bytes):
                         memory_id = memory_id.decode("utf-8")
-                    
+
                     # Get the memory data
                     memory_key = self._get_memory_key(agent_id, memory_id)
                     memory_data = self.redis.get(memory_key)
-                    
+
                     if memory_data:
                         try:
                             memory = json.loads(memory_data)
                             # Apply memory type filter if needed
-                            if memory_type is None or memory.get("memory_type") == memory_type:
+                            if (
+                                memory_type is None
+                                or memory.get("memory_type") == memory_type
+                            ):
                                 # Update access metadata and add to results
-                                self._update_access_metadata(agent_id, memory_id, memory)
+                                self._update_access_metadata(
+                                    agent_id, memory_id, memory
+                                )
                                 results.append(memory)
                         except json.JSONDecodeError:
-                            logger.warning(f"Failed to parse memory data for ID {memory_id}")
-                
+                            logger.warning(
+                                f"Failed to parse memory data for ID {memory_id}"
+                            )
+
                 return results
-            
+
             # If no timeline index exists, use SCAN with pattern matching and step filtering
             pattern = f"{self._key_prefix}:{agent_id}:memory:*"
             cursor = 0
             results = []
-            
+
             while True:
                 cursor, keys = self.redis.scan(cursor=cursor, match=pattern, count=100)
-                
+
                 if not keys:
                     if cursor == 0:
                         break
                     continue
-                
+
                 # Get memory data for each key using pipeline for efficiency
                 pipe = self.redis.pipeline()
                 for key in keys:
                     if isinstance(key, bytes):
                         key = key.decode("utf-8")
                     pipe.get(key)
-                
+
                 memory_data_list = pipe.execute()
-                
+
                 # Process memory data
                 for i, memory_data in enumerate(memory_data_list):
                     if not memory_data:
                         continue
-                    
+
                     try:
                         memory = json.loads(memory_data)
                         step = memory.get("step_number")
-                        
+
                         # Filter by step range
                         if step is not None and start_step <= step <= end_step:
                             # Apply memory type filter if needed
-                            if memory_type is None or memory.get("memory_type") == memory_type:
+                            if (
+                                memory_type is None
+                                or memory.get("memory_type") == memory_type
+                            ):
                                 # Extract memory ID from key
                                 key = keys[i]
                                 if isinstance(key, bytes):
                                     key = key.decode("utf-8")
                                 memory_id = key.split(":")[-1]
-                                
+
                                 # Update access metadata and add to results
-                                self._update_access_metadata(agent_id, memory_id, memory)
+                                self._update_access_metadata(
+                                    agent_id, memory_id, memory
+                                )
                                 results.append(memory)
                     except json.JSONDecodeError:
                         continue
-                
+
                 if cursor == 0:
                     break
-            
+
             return results
-            
+
         except Exception as e:
             # If Redis operations fail, fall back to retrieving all and filtering
-            logger.warning(f"Optimized step range search failed, using full fallback: {e}")
+            logger.warning(
+                f"Optimized step range search failed, using full fallback: {e}"
+            )
             memories = self.get_all(agent_id)
 
             # Filter by step range

--- a/memory/storage/redis_im.py
+++ b/memory/storage/redis_im.py
@@ -338,7 +338,9 @@ class RedisIMStore:
 
             # Generate checksum for content if not already in metadata
             metadata = memory_entry.get("metadata", {})
-            if "checksum" not in metadata and isinstance(content, (dict, list)):
+            if "checksum" not in metadata:
+                if not isinstance(content, (dict, list)):
+                    content = str(content)  # Convert non-dict/non-list content to string
                 metadata["checksum"] = generate_checksum(content)
 
             # Store metadata as JSON

--- a/memory/utils/__init__.py
+++ b/memory/utils/__init__.py
@@ -4,6 +4,11 @@ This package provides various utility functions and classes used throughout
 the agent memory system for serialization, Redis operations, and error handling.
 """
 
+from memory.utils.checksums import (
+    add_checksum_to_memory,
+    generate_checksum,
+    validate_checksum,
+)
 from memory.utils.error_handling import (
     CircuitBreaker,
     CircuitOpenError,
@@ -17,8 +22,8 @@ from memory.utils.error_handling import (
     RecoveryQueue,
     RedisTimeoutError,
     RedisUnavailableError,
-    RetryPolicy,
     RetryableOperation,
+    RetryPolicy,
     SQLitePermanentError,
     SQLiteTemporaryError,
     STMError,
@@ -50,6 +55,10 @@ from memory.utils.serialization import (
 )
 
 __all__ = [
+    # Checksum utilities
+    "add_checksum_to_memory",
+    "generate_checksum",
+    "validate_checksum",
     # Serialization
     "MemorySerializer",
     "serialize_memory",

--- a/memory/utils/checksums.py
+++ b/memory/utils/checksums.py
@@ -76,12 +76,13 @@ def validate_checksum(memory_entry: Dict[str, Any], strict: bool = False) -> boo
         content = memory_entry.get("content", {})
 
     # Use same algorithm as stored checksum if detectable
-    algorithm = "sha256"  # Default
-    if stored_checksum and len(stored_checksum) == 64:
-        algorithm = "sha256"
-    elif stored_checksum and len(stored_checksum) == 128:
-        algorithm = "sha512"
-
+    algorithm = metadata.get("algorithm", "sha256")  # Default to sha256 if not specified
+    if not algorithm and stored_checksum:
+        # Fallback to length-based inference for backward compatibility
+        if len(stored_checksum) == 64:
+            algorithm = "sha256"
+        elif len(stored_checksum) == 128:
+            algorithm = "sha512"
     computed_checksum = generate_checksum(content, algorithm)
 
     # Compare checksums

--- a/memory/utils/checksums.py
+++ b/memory/utils/checksums.py
@@ -1,0 +1,134 @@
+"""Checksum Utilities for Agent Memory
+
+This module provides functions for generating and validating checksums for memory entries,
+ensuring data integrity throughout the memory lifecycle. Checksums are computed based on
+memory content and select metadata fields, providing a way to detect data corruption or
+unauthorized modifications.
+
+These utilities support the memory integrity features of the agent memory system by:
+1. Computing consistent checksums for memory entries
+2. Validating checksums when memories are retrieved or transferred
+3. Supporting different hashing algorithms for various security requirements
+"""
+
+import copy
+import hashlib
+import json
+from typing import Any, Dict
+
+
+def generate_checksum(memory_content: Dict[str, Any], algorithm: str = "sha256") -> str:
+    """Generate a checksum for memory content.
+
+    Creates a reproducible hash of memory content to detect data corruption or tampering.
+
+    Args:
+        memory_content: Dictionary containing the memory contents
+        algorithm: Hashing algorithm to use (default: sha256)
+
+    Returns:
+        String representation of the content hash
+
+    Raises:
+        ValueError: If an unsupported hashing algorithm is specified
+    """
+    if algorithm not in hashlib.algorithms_guaranteed:
+        raise ValueError(f"Unsupported hashing algorithm: {algorithm}")
+
+    # Sort keys to ensure consistent serialization
+    serialized = json.dumps(memory_content, sort_keys=True)
+
+    # Create hash object with selected algorithm
+    hash_obj = hashlib.new(algorithm)
+    hash_obj.update(serialized.encode("utf-8"))
+
+    return hash_obj.hexdigest()
+
+
+def validate_checksum(memory_entry: Dict[str, Any], strict: bool = False) -> bool:
+    """Validate the checksum of a memory entry.
+
+    Verifies that a memory entry's content matches its stored checksum,
+    ensuring data integrity.
+
+    Args:
+        memory_entry: Complete memory entry including content and metadata
+        strict: If True, raises an exception on validation failure;
+               if False, returns False (default: False)
+
+    Returns:
+        True if checksum is valid or missing, False if invalid
+
+    Raises:
+        ValueError: If strict=True and checksum validation fails
+    """
+    # Extract the stored checksum if present
+    metadata = memory_entry.get("metadata", {})
+    stored_checksum = metadata.get("checksum")
+
+    # If no checksum exists, validation passes by default
+    if not stored_checksum:
+        return True
+
+    # Generate a new checksum from the content
+    content = memory_entry.get("contents", {})
+    if not content:
+        content = memory_entry.get("content", {})
+
+    # Use same algorithm as stored checksum if detectable
+    algorithm = "sha256"  # Default
+    if stored_checksum and len(stored_checksum) == 64:
+        algorithm = "sha256"
+    elif stored_checksum and len(stored_checksum) == 128:
+        algorithm = "sha512"
+
+    computed_checksum = generate_checksum(content, algorithm)
+
+    # Compare checksums
+    is_valid = computed_checksum == stored_checksum
+
+    if not is_valid and strict:
+        raise ValueError(
+            f"Checksum validation failed. Stored: {stored_checksum}, Computed: {computed_checksum}"
+        )
+
+    return is_valid
+
+
+def add_checksum_to_memory(
+    memory_entry: Dict[str, Any], algorithm: str = "sha256"
+) -> Dict[str, Any]:
+    """Add or update a checksum in a memory entry.
+
+    Computes and adds a checksum to the metadata of a memory entry.
+
+    Args:
+        memory_entry: Memory entry to update
+        algorithm: Hashing algorithm to use (default: sha256)
+
+    Returns:
+        Updated memory entry with checksum in metadata
+
+    Raises:
+        ValueError: If memory entry lacks required content field
+    """
+    # Create a deep copy to avoid modifying the original
+    memory_copy = copy.deepcopy(memory_entry)
+
+    # Ensure metadata exists
+    if "metadata" not in memory_copy:
+        memory_copy["metadata"] = {}
+
+    # Get content field (could be named "content" or "contents")
+    content = memory_copy.get("contents", {})
+    if not content:
+        content = memory_copy.get("content", {})
+
+    if not content:
+        raise ValueError("Memory entry must contain 'content' or 'contents' field")
+
+    # Generate and store checksum
+    checksum = generate_checksum(content, algorithm)
+    memory_copy["metadata"]["checksum"] = checksum
+
+    return memory_copy

--- a/tests/test_checksums.py
+++ b/tests/test_checksums.py
@@ -1,0 +1,152 @@
+"""Tests for memory checksum utilities."""
+
+import json
+import pytest
+from memory.utils.checksums import (
+    generate_checksum,
+    validate_checksum,
+    add_checksum_to_memory,
+)
+
+
+def test_generate_checksum():
+    """Test generating checksums for memory content."""
+    # Test with dictionary content
+    content1 = {"key1": "value1", "key2": 42}
+    checksum1 = generate_checksum(content1)
+    assert isinstance(checksum1, str)
+    assert len(checksum1) > 0
+
+    # Test with same content but different order (should be the same checksum)
+    content2 = {"key2": 42, "key1": "value1"}
+    checksum2 = generate_checksum(content2)
+    assert checksum1 == checksum2
+
+    # Test with different content
+    content3 = {"key1": "value1", "key2": 43}
+    checksum3 = generate_checksum(content3)
+    assert checksum1 != checksum3
+
+    # Test with nested content
+    content4 = {"key1": "value1", "nested": {"a": 1, "b": 2}}
+    checksum4 = generate_checksum(content4)
+    assert isinstance(checksum4, str)
+    assert checksum1 != checksum4
+
+
+def test_validate_checksum():
+    """Test validating checksums for memory entries."""
+    # Create a memory entry with content
+    content = {"observation": "User asked about the weather", "response": "It's sunny"}
+    checksum = generate_checksum(content)
+    memory_entry = {
+        "memory_id": "mem123",
+        "agent_id": "agent001",
+        "content": content,
+        "metadata": {
+            "checksum": checksum,
+            "creation_time": 1649879872.123,
+        },
+    }
+
+    # Validate the checksum (should pass)
+    assert validate_checksum(memory_entry) is True
+
+    # Modify the content and validate (should fail)
+    modified_entry = memory_entry.copy()
+    modified_entry["content"] = {
+        "observation": "User asked about something else",
+        "response": "It's sunny",
+    }
+    assert validate_checksum(modified_entry) is False
+
+    # Test with strict=True (should raise exception)
+    with pytest.raises(ValueError):
+        validate_checksum(modified_entry, strict=True)
+
+    # Test with missing checksum
+    no_checksum_entry = memory_entry.copy()
+    no_checksum_entry["metadata"] = {"creation_time": 1649879872.123}
+    assert validate_checksum(no_checksum_entry) is True  # Missing checksum passes
+
+
+def test_add_checksum_to_memory():
+    """Test adding checksums to memory entries."""
+    # Create a memory entry without checksum
+    memory_entry = {
+        "memory_id": "mem456",
+        "agent_id": "agent001",
+        "content": {"key1": "value1", "key2": 42},
+        "metadata": {
+            "creation_time": 1649879872.123,
+            "importance_score": 0.8,
+        },
+    }
+
+    # Add checksum
+    updated_entry = add_checksum_to_memory(memory_entry)
+
+    # Verify checksum was added
+    assert "checksum" in updated_entry["metadata"]
+    assert isinstance(updated_entry["metadata"]["checksum"], str)
+
+    # Verify original entry wasn't modified
+    assert "checksum" not in memory_entry["metadata"]
+
+    # Verify checksum is valid
+    assert validate_checksum(updated_entry) is True
+
+    # Test with empty content
+    empty_content_entry = {
+        "memory_id": "mem789",
+        "agent_id": "agent001",
+        "metadata": {
+            "creation_time": 1649879872.123,
+        },
+    }
+
+    # Should raise ValueError
+    with pytest.raises(ValueError):
+        add_checksum_to_memory(empty_content_entry)
+
+
+def test_checksum_different_algorithms():
+    """Test checksums with different hashing algorithms."""
+    content = {"key1": "value1", "key2": 42}
+
+    # Generate checksums with different algorithms
+    sha256_checksum = generate_checksum(content, algorithm="sha256")
+    sha512_checksum = generate_checksum(content, algorithm="sha512")
+
+    # Verify they're different
+    assert sha256_checksum != sha512_checksum
+    assert len(sha512_checksum) > len(sha256_checksum)
+
+    # Test with invalid algorithm
+    with pytest.raises(ValueError):
+        generate_checksum(content, algorithm="invalid_algorithm")
+
+
+def test_checksum_serialization():
+    """Test that checksums remain valid after serialization/deserialization."""
+    # Create memory entry with checksum
+    content = {"observation": "User asked about the weather"}
+    memory_entry = {
+        "memory_id": "mem123",
+        "agent_id": "agent001",
+        "content": content,
+        "metadata": {
+            "creation_time": 1649879872.123,
+            "importance_score": 0.8,
+        },
+    }
+
+    # Add checksum
+    memory_entry = add_checksum_to_memory(memory_entry)
+
+    # Serialize and deserialize
+    serialized = json.dumps(memory_entry)
+    deserialized = json.loads(serialized)
+
+    # Validate checksum still passes
+    assert validate_checksum(deserialized) is True


### PR DESCRIPTION
This commit introduces a new script, `add_checksums_to_samples.py`, which processes memory JSON files in the `demos/memory_samples` directory to add checksums to each memory entry's metadata. The checksum is generated using a new utility module, `memory/utils/checksums.py`, which includes functions for generating and validating checksums. Additionally, existing memory sample files are updated to include the new `checksum` field, enhancing data integrity verification across the memory system. Unit tests for the checksum utilities are also added to ensure functionality and reliability.